### PR TITLE
ensures that user ops are strings for node-side deserialization; use eip-55 address for userop sender

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -32,7 +32,7 @@ export class UserOperationSignatureRequest {
 
   toBytes(): Uint8Array {
     const data = {
-      user_op: this.userOp,
+      user_op: JSON.stringify(this.userOp),
       aa_version: this.aaVersion,
       cohort_id: this.cohortId,
       chain_id: this.chainId,

--- a/packages/taco/integration-test/sign.test.ts
+++ b/packages/taco/integration-test/sign.test.ts
@@ -6,7 +6,7 @@ import { initialize } from '../src';
 import { signUserOp } from '../src/sign';
 
 const RPC_PROVIDER_URL = 'https://ethereum-sepolia-rpc.publicnode.com';
-const DUMMY_ADDRESS = '0x742d35Cc6634C0532925a3b8D33C9c0E7b66C8E8';
+const DUMMY_ADDRESS = '0x742D35Cc6634C0532925A3b8D33c9c0E7B66C8E8';
 const DOMAIN = 'lynx';
 const RITUAL_ID = 1;
 const CHAIN_ID = 11155111;
@@ -73,4 +73,4 @@ describe.skipIf(!process.env.RUNNING_IN_CI)('Taco Sign Integration Test', () => 
     expect(signResult.signingResults).toBeDefined();
     expect(Object.keys(signResult.signingResults).length).toBeGreaterThan(0);
   }, 150000);
-}); 
+});

--- a/packages/taco/test/taco-sign.test.ts
+++ b/packages/taco/test/taco-sign.test.ts
@@ -73,7 +73,7 @@ describe('TACo Signing', () => {
       expect(signUserOpMock).toHaveBeenCalledWith(
         {
           '0x5678': btoa(JSON.stringify({
-            user_op: pythonUserOp,
+            user_op: JSON.stringify(pythonUserOp),
             aa_version: aaVersion,
             cohort_id: cohortId,
             chain_id: chainId,
@@ -81,7 +81,7 @@ describe('TACo Signing', () => {
             signature_type: "userop"
           })),
           '0xefgh': btoa(JSON.stringify({
-            user_op: pythonUserOp,
+            user_op: JSON.stringify(pythonUserOp),
             aa_version: aaVersion,
             cohort_id: cohortId,
             chain_id: chainId,
@@ -138,7 +138,7 @@ describe('TACo Signing', () => {
       expect(signUserOpMock).toHaveBeenCalledWith(
         {
           '0x5678': btoa(JSON.stringify({
-            user_op: pythonUserOp2,
+            user_op: JSON.stringify(pythonUserOp2),
             aa_version: aaVersion,
             cohort_id: cohortId,
             chain_id: chainId,
@@ -146,7 +146,7 @@ describe('TACo Signing', () => {
             signature_type: "userop"
           })),
           '0xefgh': btoa(JSON.stringify({
-            user_op: pythonUserOp2,
+            user_op: JSON.stringify(pythonUserOp2),
             aa_version: aaVersion,
             cohort_id: cohortId,
             chain_id: chainId,


### PR DESCRIPTION
## Summary by Sourcery

Ensure that user operations are serialized as strings for correct node-side deserialization and update tests accordingly.

Bug Fixes:
- Serialize the `user_op` field as a JSON string in `UserOperationSignatureRequest.toBytes()`

Tests:
- Update existing tests to expect `user_op` as a string by wrapping `pythonUserOp` with `JSON.stringify`