### PR TITLE
Viem abstraction of taco-web

### DIFF
--- a/demos/taco-aa-signing/src/taco-account.ts
+++ b/demos/taco-aa-signing/src/taco-account.ts
@@ -1,0 +1,33 @@
+import { type Address } from 'viem';
+import { toAccount } from 'viem/accounts';
+
+/**
+ * Creates a minimal Viem Account that serves as a placeholder for the MetaMask Smart Account.
+ * This account is never actually used for signing - all real signing happens through the TACo network
+ * via the separate signUserOpWithTaco function.
+ *
+ * @param cohortAddress - Address of a TACo cohort participant (used as the account address)
+ * @returns A Viem Account with stub implementations
+ */
+export function createViemTacoAccount(cohortAddress: Address) {
+  return toAccount({
+    address: cohortAddress,
+
+    // These methods are never called by the MetaMask Smart Account
+    // They only need to exist to satisfy the Account interface
+    async signMessage() {
+      return '0x' as `0x${string}`;
+    },
+
+    async signTransaction() {
+      return '0x' as `0x${string}`;
+    },
+
+    async signTypedData() {
+      return '0x' as `0x${string}`;
+    },
+  });
+}
+
+// Legacy alias - kept for backward compatibility if needed
+export const createTacoAccount = createViemTacoAccount;


### PR DESCRIPTION
## Summary by Sourcery

Integrate Viem account abstraction into the taco-web signing demo, replacing the ad-hoc private key signer with dedicated placeholder and funding accounts, and improve type safety and error handling.

Enhancements:
- Extract createViemTacoAccount utility to stub MetaMask signatory and centralize signing through the TACo network.
- Rename createTacoSmartAccount to createViemTacoSmartAccount and introduce a separate fundingAccount for funding operations distinct from the placeholder tacoAccount.
- Add inline documentation on the TACo signing architecture and enforce explicit type casting for user operation fields.
- Improve error handling in main to gracefully handle unknown errors and standardize error messages.